### PR TITLE
refactor: 💡 extract typeorm config out from api-core-feature

### DIFF
--- a/libs/api/core/feature/src/lib/api-core-feature.module.ts
+++ b/libs/api/core/feature/src/lib/api-core-feature.module.ts
@@ -3,19 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 @Module({
-  imports: [
-    ConfigModule.forRoot({ isGlobal: true }),
-    TypeOrmModule.forRoot({
-      type: 'postgres',
-      host: process.env.POSTGRES_HOST,
-      port: parseInt(process.env.POSTGRES_PORT),
-      username: process.env.POSTGRES_USER,
-      password: process.env.POSTGRES_PASSWORD,
-      database: process.env.POSTGRES_DATABASE,
-      autoLoadEntities: true,
-      synchronize: true, // shouldn't be used in production - may lose data
-    }),
-  ],
+  imports: [ConfigModule.forRoot({ isGlobal: true }), TypeOrmModule.forRoot()],
   controllers: [],
   providers: [],
   exports: [],

--- a/ormconfig.local.json
+++ b/ormconfig.local.json
@@ -1,0 +1,13 @@
+{
+  "type": "postgres",
+  "host": "localhost",
+  "port": 5432,
+  "username": "postgres",
+  "password": "password",
+  "database": "linkedin",
+  "entities": ["apps/api/**/*.entity.js"],
+  "migrations": ["apps/api/src/migrations/*"],
+  "cli": {
+    "migrationsDir": "apps/api/src/migrations"
+  }
+}


### PR DESCRIPTION
extract out nestjs' typeorm configuration from the api's core module and
migrate it to be located at ormconfig.local.json in the monorepo root