### PR TITLE
ci: 🎡 add todo workflow to monorepo

### DIFF
--- a/.github/workflows/todo.yml
+++ b/.github/workflows/todo.yml
@@ -1,0 +1,31 @@
+name: create issues from TODOs
+
+on:
+  workflow_dispatch:
+    inputs:
+      importAll:
+        default: 'false'
+        required: false
+        description: Enable, if you want to import all TODOs. Runs on checked out branch! Only use if you're sure what you are doing.
+  push:
+    branches: # do not set multiple branches, todos might be added and then get referenced by themselves in case of a merge
+      - main
+
+permissions:
+  issues: write
+  repository-projects: read
+  contents: read
+
+jobs:
+  todos:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run Issue Bot
+        uses: derjuulsn/todo-issue@main
+        with:
+          excludePattern: '^(node_modules/)'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
   "vsicons.presets.nestjs": true,
   "window.zoomLevel": 1,
   "editor.fontSize": 18,
-  "terminal.integrated.fontSize": 18
+  "terminal.integrated.fontSize": 18,
+  "github-actions.workflows.pinned.workflows": []
 }

--- a/libs/api/core/feature/src/lib/api-core-feature.module.ts
+++ b/libs/api/core/feature/src/lib/api-core-feature.module.ts
@@ -3,8 +3,8 @@ import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 @Module({
-  // @todo: test todos
-  // @body: test that both the todo plugin is activated as well as the ranger plugin
+  // TODO add imports
+  // testing to see if the todo github action is configured correctly
   imports: [ConfigModule.forRoot({ isGlobal: true }), TypeOrmModule.forRoot()],
   controllers: [],
   providers: [],


### PR DESCRIPTION
add todo workflow to monorepo (allows for issues to be generated from
todos in source code)