### PR TITLE
Feature/actions config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -22,7 +22,7 @@ github:
   - '.github/**/*'
 
 # Add 'gh-workflows' label to any github workflow configuration changes
-gh-workflows:
+gh-actions-workflows:
   - '.github/workflows/*'
   - '.github/workflows/**/*'
 

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,0 +1,20 @@
+name: 'add code coverage reports to pull requests'
+on:
+  - pull_request_target
+
+jobs:
+  coverage_for_pull_requests:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+          files: ./coverage1.xml,./coverage2.xml # optional
+          flags: unittests # optional
+          name: codecov-umbrella # optional
+          fail_ci_if_error: true # optional (default = false)
+          verbose: true # optional (default = false)

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,7 +3,7 @@ on:
   - pull_request_target
 
 jobs:
-  triage:
+  label_pull_requests:
     permissions:
       contents: read
       pull-requests: write

--- a/libs/shared/utils/compodoc-tools/project.json
+++ b/libs/shared/utils/compodoc-tools/project.json
@@ -38,6 +38,13 @@
       "configurations": {
         "json": {
           "exportFormat": "json"
+        },
+        "watch": {
+          "watch": true
+        },
+        "json-watch": {
+          "exportFormat": "json",
+          "watch": true
         }
       }
     }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] CI related changes
- [X] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Monorepo doesn't have compodoc configuration and code coverage reports on prs.

## What is the new behavior?

Introduces documentation for the entire monorepo available via compodoc in the libs/shared/utils directory. Adds code coverage report to github actions ci/cd pipeline to be displayed on pull request.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
