### PR TITLE
fix: 🐛 resolve issue with code coverage workflow

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+          version: 'v0.1.15'
           files: ./coverage1.xml,./coverage2.xml # optional
           flags: unittests # optional
           name: codecov-umbrella # optional


### PR DESCRIPTION
get code coverage workflow up and running by adding version declaration
to config to resolve the issue